### PR TITLE
Fixes to task script

### DIFF
--- a/scripts/generate-tasks.js
+++ b/scripts/generate-tasks.js
@@ -14,6 +14,7 @@ var THRESHOLD = 0.005
 var input = fs.createReadStream(process.argv[2])
 .pipe(ndjson.parse())
 collect(input, function (i) {
+  i.forEach(feature => { feature._id = feature.way_id })
   var network = {
     type: 'FeatureCollection',
     features: i

--- a/scripts/generate-tasks.sh
+++ b/scripts/generate-tasks.sh
@@ -15,7 +15,7 @@ else
 fi
 
 echo "Converting to GeoJSON"
-./to-geojson.js .tmp/waynodes.csv .tmp/waytags.csv > .tmp/network.geojson
+./to-geojson.js .tmp/waynodes.csv .tmp/waytags.csv .tmp/road_properties.csv > .tmp/network.geojson
 
 echo "Generating tasks"
 ./generate-tasks.js .tmp/network.geojson > .tmp/tasks.csv


### PR DESCRIPTION
@mileswwatkins adding in the road properties so the geojson generation script doesn't break, plus adding the `_id` field on the fly so it can get properly indexed by `networkmatch` (this property doesn't get put anywhere, since only id's are stored).