### PR TITLE
Use point-properties from the database, instead of from S3

### DIFF
--- a/scripts/conflate-points-lines.js
+++ b/scripts/conflate-points-lines.js
@@ -14,14 +14,13 @@ var fs = require('fs');
 Promise = require('bluebird');
 
 let roads = JSON.parse(fs.readFileSync(process.argv[2]).toString())
-let points = JSON.parse(fs.readFileSync(process.argv[3]).toString());
+let points = JSON.parse(fs.readFileSync(process.argv[3], 'utf-8'));
 
 const pointProperties = [
   'iri',
   'or_width',
   'or_class',
-  'or_surface',
-  'or_responsibility'
+  'or_surface'
 ];
 
 const getClosestAttributes = (midpoint, possiblePoints) => {

--- a/scripts/make-analysis-and-display.sh
+++ b/scripts/make-analysis-and-display.sh
@@ -7,17 +7,16 @@ echo "Ensure the necessary environment variables are set"
 : "${AWS_ACCESS_KEY_ID:?}"
 : "${AWS_SECRET_ACCESS_KEY:?}"
 : "${MAPBOX_ACCESS_TOKEN:?}"
+: "${MAPBOX_ACCOUNT:?}"
 # Paths
 : "${S3_DUMP_BUCKET:?}"
-: "${S3_PROPERTIES_BUCKET:?}"
-: "${MAPBOX_ACCOUNT:?}"
 
 # Change to script's directory
 cd "${0%/*}"
 
 mkdir -p .tmp
 
-echo "Dumping ways from database"
+echo "Dumping ways and properties from database"
 psql "$DATABASE_URL" < ways.sql
 
 echo "Converting network to GeoJSON"
@@ -28,24 +27,10 @@ split --lines 1 .tmp/network.geojson ".tmp/network/"
     .tmp/network/* \
     > .tmp/network-merged.geojson
 
-echo "Get all point-property data from S3"
-mkdir .tmp/points
-aws s3 cp \
-    --recursive --include "*.geojson" \
-    "s3://${S3_PROPERTIES_BUCKET}/points" \
-    .tmp/points
-../node_modules/.bin/geojson-merge \
-    .tmp/points/*.geojson \
-    > .tmp/points.geojson
-../node_modules/.bin/reproject \
-    --use-spatialreference --from EPSG:32648 --to EPSG:4326 \
-    .tmp/points.geojson \
-    > .tmp/points-wgs84.geojson
-
 echo "Conflate point data's core OR attributes onto network lines"
 ./conflate-points-lines.js \
     .tmp/network-merged.geojson \
-    .tmp/points-wgs84.geojson \
+    .tmp/points.geojson \
     .tmp/conflated.geojson
 
 echo "Convert to vector tiles, and upload to Mapbox"

--- a/scripts/ways.sql
+++ b/scripts/ways.sql
@@ -19,7 +19,7 @@ BEGIN;
     SELECT JSONB_BUILD_OBJECT(
       'type', 'Feature',
       'geometry', ST_ASGEOJSON(geom)::JSONB,
-      'properties', properties
+      'properties', properties || JSONB_BUILD_OBJECT('or_vpromms', road_id)
     ) AS feature
     FROM point_properties;
   CREATE TEMP VIEW point_featurecollection AS


### PR DESCRIPTION
@matthewhanson: note that this PR makes the `S3_PROPERTIES_BUCKET` unnecessary going forward, since we don't use it anywhere anymore (https://github.com/orma/openroads-vn-api/blob/master/docker-compose.yml#L37).

closes https://github.com/orma/openroads-vn-analytics/issues/116