### PR TITLE
add step to strip out extra properties from sections geojson

### DIFF
--- a/scripts/make-analysis-and-display.sh
+++ b/scripts/make-analysis-and-display.sh
@@ -30,36 +30,21 @@ mkdir -p $WORKDIR/network
 
 # geojson-stream-merge --input $WORKDIR/network.geojson --output $WORKDIR/network-merged.geojson
 
-echo "Adding IRI date to GeoJSON"
+echo "Adding IRI data to GeoJSON"
 ./add-iri-to-geojson.js $WORKDIR/network.geojson $WORKDIR/points.geojson > $WORKDIR/orma-sections.geojson
 
 echo "Creating CSV for CBA export"
 ./create-cba_export.js $WORKDIR/orma-sections.geojson > $WORKDIR/orma-sections.csv
+
 # echo "Upload the export to S3. Note that this needs to be changes to a location accessible by CBA scripts."
 aws s3 cp \
     --acl public-read \
     "${WORKDIR}/orma-sections.csv" \
     "s3://${S3_DUMP_BUCKET}/cba/orma-sections-$(date +%Y-%m-%d).csv"
 
-## Note - since we're using WON, we don't need to conflate with the national network.
-## National network will now be moved to another tileset on Mapbox.
+echo "Creating GeoJSON with extra properties stripped out"
+./strip-extra-properties.js $WORKDIR/orma-sections.geojson > $WORKDIR/orma-sections-trimmed.geojson
 
-# echo "Downloading national highways, which aren't tracked in ORMA"
-# aws s3 cp \
-#     "s3://$S3_DUMP_BUCKET/private-fixture-data/National_network.geojson" \
-#     "$WORKDIR/National_network.geojson"
-
-# echo "Conflate point data's core OR attributes onto network lines"
-# ./conflate-points-lines.js \
-#     $WORKDIR/network-merged.geojson \
-#     $WORKDIR/points.geojson \
-#     $WORKDIR/conflated.geojson
-
-# echo "Merging conflated ORMA roads and national highways into one network file"
-# ../node_modules/.bin/geojson-merge \
-#     $WORKDIR/National_network.geojson \
-#     $WORKDIR/conflated.geojson > \
-#     $WORKDIR/all-roads.geojson
 
 echo "Convert to vector tiles, and upload to Mapbox"
 tippecanoe \
@@ -67,7 +52,7 @@ tippecanoe \
     --minimum-zoom 0 --maximum-zoom 16 \
     --drop-smallest-as-needed \
     --force --output "$WORKDIR/conflated.mbtiles" \
-    "$WORKDIR/orma-sections.geojson"
+    "$WORKDIR/orma-sections-trimmed.geojson"
 
 export MapboxAccessToken=$MAPBOX_ACCESS_TOKEN
 mapbox-upload \

--- a/scripts/strip-extra-properties.js
+++ b/scripts/strip-extra-properties.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+'use strict'
+const fs = require('fs')
+const ndjson = require('ndjson')
+const collect = require('stream-collect')
+const _ = require('lodash');
+
+// read all sections from the network
+const input = fs.createReadStream(process.argv[2])
+.pipe(ndjson.parse())
+
+// const headers = ['orma_way_id', 'vpromm_id', 'iri_mean', 'or_section_delivery_vehicle'];
+
+collect(input, (sections) => {
+
+    sections.forEach(feature => {
+        const allProps = JSON.parse(JSON.stringify(feature.properties));
+        feature.properties = {};
+        feature.properties['orma_way_id'] = feature.way_id;
+        feature.properties['vpromm_id'] = allProps.or_vpromms || null;
+        feature.properties['iri_mean'] = allProps.iri_mean || null;
+        feature.properties['or_section_delivery_vehicle'] = parseFloat(allProps.or_section_delivery_vehicle) || 0;
+        process.stdout.write(JSON.stringify(feature));
+        process.stdout.write('\n'); 
+    });
+});
+


### PR DESCRIPTION
@geohacker - this adds a step to strip out all the un-needed properties from the  sections geojson before cutting tiles. Also casts the `or_section_delivery_vehicle` value to a float to enable easier filtering on the frontend.

If this looks okay, let me know if I can help with deploying / running it.